### PR TITLE
Minor change in the IAM role creation segment

### DIFF
--- a/doc_source/ex-book-trip-create-lambda-function.md
+++ b/doc_source/ex-book-trip-create-lambda-function.md
@@ -12,7 +12,7 @@ This Lambda function is written in Python\.
 
 1. Configure the Lambda function as follows and then choose **Create Function**\.
    + Type a Lambda function name \(`BookTripCodeHook`\)\.
-   + For the role, choose **Create a new role from template\(s\)** and then type a role name\.
+   + For the role, choose **Create a new role from AWS policy templates** and then type a role name\.
    + Leave the other default values\.
 
 1. Test the Lambda function\. You invoke the Lambda function twice, using sample data for both booking a car and booking a hotel\. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While creating a new role for the bot in the lambda console, the drop down text in the UI has been updated to **Create a new role from AWS policy templates** from **Create a new role from template(s)**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
