### PR TITLE
Updated bot limit info

### DIFF
--- a/doc_source/gl-limits.md
+++ b/doc_source/gl-limits.md
@@ -94,7 +94,7 @@ Model building refers to creating and managing bots\. This includes creating and
 + You can create up to five aliases for a bot\.
 
    
-+ You can create up to 100 bots per AWS account\.
++ You can create up to 100 bots per region\.
 
    
 + You cannot create multiple intents that extend from the same built\-in intent\.


### PR DESCRIPTION
Changes the bot limit info description from 'per account' to 'per region' in order to reflect the actual behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
